### PR TITLE
Implement arbitrary suffixes (for all literals)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,10 @@ jobs:
       run: |
         cargo test --release --no-default-features --lib -- --include-ignored
         cargo test --doc --no-default-features
+
+    - name: Build with check_suffix
+      run: cargo build --features=check_suffix
+    - name: Run tests with check_suffix
+      run: |
+        cargo test --release --features=check_suffix --lib -- --include-ignored
+        cargo test --doc --features=check_suffix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ exclude = [".github"]
 
 [features]
 default = ["proc-macro2"]
+check_suffix = ["unicode-xid"]
 
 [dependencies]
 proc-macro2 = { version = "1", optional = true }
+unicode-xid = { version = "0.2.4", optional = true }

--- a/examples/procmacro/examples/main.rs
+++ b/examples/procmacro/examples/main.rs
@@ -1,4 +1,4 @@
-use procmacro_example::{concat, repeat};
+use procmacro_example::{concat, dbg_and_swallow, repeat};
 
 const FOO: &str = concat!(r#"Hello "# '🦊' "\nHere is a friend: \u{1F427}");
 // const FOO: &str = concat!(::);
@@ -8,6 +8,7 @@ const BAR: &str = repeat!(3 * "నా పిల్లి లావుగా ఉ�
 const BAZ: &str = repeat!(0b101 * "🦀");
 // const BAZ: &str = repeat!(3.5 * "🦀");
 
+dbg_and_swallow!(16px);
 
 fn main() {
     println!("{}", FOO);

--- a/examples/procmacro/src/lib.rs
+++ b/examples/procmacro/src/lib.rs
@@ -3,6 +3,14 @@ use proc_macro::{Spacing, TokenStream, TokenTree};
 use litrs::{Literal, IntegerLit, StringLit};
 
 
+#[proc_macro]
+pub fn dbg_and_swallow(input: TokenStream) -> TokenStream {
+    for token in input {
+        println!("{} -> {:#?}", token, Literal::try_from(&token));
+    }
+    TokenStream::new()
+}
+
 /// Concatinates all input string and char literals into a single output string
 /// literal.
 #[proc_macro]

--- a/src/err.rs
+++ b/src/err.rs
@@ -221,13 +221,6 @@ pub(crate) enum ParseErrorKind {
     /// Integer literal does not contain any valid digits.
     NoDigits,
 
-    /// Found a integer type suffix that is invalid.
-    InvalidIntegerTypeSuffix,
-
-    /// Found a float type suffix that is invalid. Only `f32` and `f64` are
-    /// valid.
-    InvalidFloatTypeSuffix,
-
     /// Exponent of a float literal does not contain any digits.
     NoExponentDigits,
 
@@ -309,6 +302,17 @@ pub(crate) enum ParseErrorKind {
     /// An literal `\r` character not followed by a `\n` character in a
     /// (raw) string or byte string literal.
     IsolatedCr,
+
+    /// Literal suffix is not a valid identifier.
+    InvalidSuffix,
+
+    /// Returned by `Float::parse` if an integer literal (no fractional nor
+    /// exponent part) is passed.
+    UnexpectedIntegerLit,
+
+    /// Integer suffixes cannot start with `e` or `E` as this conflicts with the
+    /// grammar for float literals.
+    IntegerSuffixStartingWithE,
 }
 
 impl std::error::Error for ParseError {}
@@ -324,8 +328,6 @@ impl fmt::Display for ParseError {
             DoesNotStartWithDigit => "number literal does not start with decimal digit",
             InvalidDigit => "integer literal contains a digit invalid for its base",
             NoDigits => "integer literal does not contain any digits",
-            InvalidIntegerTypeSuffix => "invalid integer type suffix",
-            InvalidFloatTypeSuffix => "invalid floating point type suffix",
             NoExponentDigits => "exponent of floating point literal does not contain any digits",
             UnknownEscape => "unknown escape",
             UnterminatedEscape => "unterminated escape: input ended too soon",
@@ -354,6 +356,9 @@ impl fmt::Display for ParseError {
             InvalidByteLiteralStart => "invalid start for byte literal",
             InvalidByteStringLiteralStart => "invalid start for byte string literal",
             IsolatedCr => r"`\r` not immediately followed by `\n` in string",
+            InvalidSuffix => "literal suffix is not a valid identifier",
+            UnexpectedIntegerLit => "expected float literal, but found integer",
+            IntegerSuffixStartingWithE => "integer literal suffix must not start with 'e' or 'E'",
         };
 
         description.fmt(f)?;

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 use crate::{
     Buffer, ParseError,
@@ -55,13 +55,6 @@ pub struct FloatLit<B: Buffer> {
 
     /// Optional type suffix.
     type_suffix: Option<FloatType>,
-}
-
-/// All possible float type suffixes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FloatType {
-    F32,
-    F64,
 }
 
 impl<B: Buffer> FloatLit<B> {
@@ -224,6 +217,49 @@ pub(crate) fn parse_impl(input: &str) -> Result<FloatLit<&str>, ParseError> {
         type_suffix,
     })
 }
+
+
+/// All possible float type suffixes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatType {
+    F32,
+    F64,
+}
+
+impl FloatType {
+    /// Returns the type corresponding to the given suffix (e.g. `"f32"` is
+    /// mapped to `Self::F32`). If the suffix is not a valid float type, `None`
+    /// is returned.
+    pub fn from_suffix(suffix: &str) -> Option<Self> {
+        match suffix {
+            "f32" => Some(FloatType::F32),
+            "f64" => Some(FloatType::F64),
+            _ => None,
+        }
+    }
+
+    /// Returns the suffix for this type, e.g. `"f32"` for `Self::F32`.
+    pub fn suffix(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+}
+
+impl FromStr for FloatType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_suffix(s).ok_or(())
+    }
+}
+
+impl fmt::Display for FloatType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.suffix().fmt(f)
+    }
+}
+
 
 #[cfg(test)]
 mod tests;

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -3,7 +3,7 @@ use std::{fmt, str::FromStr};
 use crate::{
     Buffer, ParseError,
     err::{perr, ParseErrorKind::*},
-    parse::{end_dec_digits, first_byte_or_empty},
+    parse::{end_dec_digits, first_byte_or_empty, check_suffix},
 };
 
 
@@ -52,14 +52,13 @@ pub struct FloatLit<B: Buffer> {
 
     /// The first index after the whole number part (everything except type suffix).
     end_number_part: usize,
-
-    /// Optional type suffix.
-    type_suffix: Option<FloatType>,
 }
 
 impl<B: Buffer> FloatLit<B> {
     /// Parses the input as a floating point literal. Returns an error if the
-    /// input is invalid or represents a different kind of literal.
+    /// input is invalid or represents a different kind of literal. Will also
+    /// reject decimal integer literals like `23` or `17f32`, in accordance
+    /// with the spec.
     pub fn parse(s: B) -> Result<Self, ParseError> {
         match first_byte_or_empty(&s)? {
             b'0'..=b'9' => {
@@ -68,26 +67,19 @@ impl<B: Buffer> FloatLit<B> {
                     end_integer_part,
                     end_fractional_part,
                     end_number_part,
-                    type_suffix,
                     ..
                 } = parse_impl(&s)?;
 
-                Ok(Self {
-                    raw: s,
-                    end_integer_part,
-                    end_fractional_part,
-                    end_number_part,
-                    type_suffix,
-                })
+                Ok(Self { raw: s, end_integer_part, end_fractional_part, end_number_part })
             },
             _ => Err(perr(0, DoesNotStartWithDigit)),
         }
     }
 
-    /// Returns the whole number part (including integer part, fractional part
-    /// and exponent), but without the type suffix. If you want an actual
-    /// floating point value, you need to parse this string, e.g. with
-    /// `f32::from_str` or an external crate.
+    /// Returns the number part (including integer part, fractional part and
+    /// exponent), but without the suffix. If you want an actual floating
+    /// point value, you need to parse this string, e.g. with `f32::from_str`
+    /// or an external crate.
     pub fn number_part(&self) -> &str {
         &(*self.raw)[..self.end_number_part]
     }
@@ -114,9 +106,9 @@ impl<B: Buffer> FloatLit<B> {
         &(*self.raw)[self.end_fractional_part..self.end_number_part]
     }
 
-    /// The optional type suffix.
-    pub fn type_suffix(&self) -> Option<FloatType> {
-        self.type_suffix
+    /// The optional suffix. Returns `""` if the suffix is empty/does not exist.
+    pub fn suffix(&self) -> &str {
+        &(*self.raw)[self.end_number_part..]
     }
 
     /// Returns the raw input that was passed to `parse`.
@@ -139,7 +131,6 @@ impl FloatLit<&str> {
             end_integer_part: self.end_integer_part,
             end_fractional_part: self.end_fractional_part,
             end_number_part: self.end_number_part,
-            type_suffix: self.type_suffix,
         }
     }
 }
@@ -177,7 +168,6 @@ pub(crate) fn parse_impl(input: &str) -> Result<FloatLit<&str>, ParseError> {
         return Err(perr(end_integer_part + 1, UnexpectedChar));
     }
 
-
     // Optional exponent.
     let end_number_part = if rest.starts_with('e') || rest.starts_with('E') {
         // Strip single - or + sign at the beginning.
@@ -200,21 +190,21 @@ pub(crate) fn parse_impl(input: &str) -> Result<FloatLit<&str>, ParseError> {
         end_fractional_part
     };
 
+    // Make sure the suffix is valid.
+    let suffix = &input[end_number_part..];
+    check_suffix(suffix).map_err(|kind| perr(end_number_part..input.len(), kind))?;
 
-    // Type suffix
-    let type_suffix = match &input[end_number_part..] {
-        "" => None,
-        "f32" => Some(FloatType::F32),
-        "f64" => Some(FloatType::F64),
-        _ => return Err(perr(end_number_part..input.len(), InvalidFloatTypeSuffix)),
-    };
+    // A float literal needs either a fractional or exponent part, otherwise its
+    // an integer literal.
+    if end_integer_part == end_number_part {
+        return Err(perr(None, UnexpectedIntegerLit));
+    }
 
     Ok(FloatLit {
         raw: input,
         end_integer_part,
         end_fractional_part,
         end_number_part,
-        type_suffix,
     })
 }
 

--- a/src/float/tests.rs
+++ b/src/float/tests.rs
@@ -20,18 +20,18 @@ macro_rules! check {
             end_integer_part: $intpart.len(),
             end_fractional_part: $intpart.len() + $fracpart.len(),
             end_number_part: $intpart.len() + $fracpart.len() + $exppart.len(),
-            type_suffix: check!(@ty $suffix),
         };
 
         assert_parse_ok_eq(
             input, FloatLit::parse(input), expected_float.clone(), "FloatLit::parse");
         assert_parse_ok_eq(
             input, Literal::parse(input), Literal::Float(expected_float), "Literal::parse");
+        assert_eq!(FloatLit::parse(input).unwrap().suffix(), check!(@ty $suffix));
         assert_roundtrip(expected_float.to_owned(), input);
     };
-    (@ty f32) => { Some(FloatType::F32) };
-    (@ty f64) => { Some(FloatType::F64) };
-    (@ty -) => { None };
+    (@ty f32) => { "f32" };
+    (@ty f64) => { "f64" };
+    (@ty -) => { "" };
     (@stringify_suffix -) => { "" };
     (@stringify_suffix $suffix:ident) => { stringify!($suffix) };
 }
@@ -46,42 +46,42 @@ fn manual_without_suffix() -> Result<(), ParseError> {
     assert_eq!(f.integer_part(), "3");
     assert_eq!(f.fractional_part(), Some("14"));
     assert_eq!(f.exponent_part(), "");
-    assert_eq!(f.type_suffix(), None);
+    assert_eq!(f.suffix(), "");
 
     let f = FloatLit::parse("9.")?;
     assert_eq!(f.number_part(), "9.");
     assert_eq!(f.integer_part(), "9");
     assert_eq!(f.fractional_part(), Some(""));
     assert_eq!(f.exponent_part(), "");
-    assert_eq!(f.type_suffix(), None);
+    assert_eq!(f.suffix(), "");
 
     let f = FloatLit::parse("8e1")?;
     assert_eq!(f.number_part(), "8e1");
     assert_eq!(f.integer_part(), "8");
     assert_eq!(f.fractional_part(), None);
     assert_eq!(f.exponent_part(), "e1");
-    assert_eq!(f.type_suffix(), None);
+    assert_eq!(f.suffix(), "");
 
     let f = FloatLit::parse("8E3")?;
     assert_eq!(f.number_part(), "8E3");
     assert_eq!(f.integer_part(), "8");
     assert_eq!(f.fractional_part(), None);
     assert_eq!(f.exponent_part(), "E3");
-    assert_eq!(f.type_suffix(), None);
+    assert_eq!(f.suffix(), "");
 
     let f = FloatLit::parse("8_7_6.1_23e15")?;
     assert_eq!(f.number_part(), "8_7_6.1_23e15");
     assert_eq!(f.integer_part(), "8_7_6");
     assert_eq!(f.fractional_part(), Some("1_23"));
     assert_eq!(f.exponent_part(), "e15");
-    assert_eq!(f.type_suffix(), None);
+    assert_eq!(f.suffix(), "");
 
     let f = FloatLit::parse("8.2e-_04_9")?;
     assert_eq!(f.number_part(), "8.2e-_04_9");
     assert_eq!(f.integer_part(), "8");
     assert_eq!(f.fractional_part(), Some("2"));
     assert_eq!(f.exponent_part(), "e-_04_9");
-    assert_eq!(f.type_suffix(), None);
+    assert_eq!(f.suffix(), "");
 
     Ok(())
 }
@@ -93,28 +93,28 @@ fn manual_with_suffix() -> Result<(), ParseError> {
     assert_eq!(f.integer_part(), "3");
     assert_eq!(f.fractional_part(), Some("14"));
     assert_eq!(f.exponent_part(), "");
-    assert_eq!(f.type_suffix(), Some(FloatType::F32));
+    assert_eq!(FloatType::from_suffix(f.suffix()), Some(FloatType::F32));
 
     let f = FloatLit::parse("8e1f64")?;
     assert_eq!(f.number_part(), "8e1");
     assert_eq!(f.integer_part(), "8");
     assert_eq!(f.fractional_part(), None);
     assert_eq!(f.exponent_part(), "e1");
-    assert_eq!(f.type_suffix(), Some(FloatType::F64));
+    assert_eq!(FloatType::from_suffix(f.suffix()), Some(FloatType::F64));
 
     let f = FloatLit::parse("8_7_6.1_23e15f32")?;
     assert_eq!(f.number_part(), "8_7_6.1_23e15");
     assert_eq!(f.integer_part(), "8_7_6");
     assert_eq!(f.fractional_part(), Some("1_23"));
     assert_eq!(f.exponent_part(), "e15");
-    assert_eq!(f.type_suffix(), Some(FloatType::F32));
+    assert_eq!(FloatType::from_suffix(f.suffix()), Some(FloatType::F32));
 
     let f = FloatLit::parse("8.2e-_04_9f64")?;
     assert_eq!(f.number_part(), "8.2e-_04_9");
     assert_eq!(f.integer_part(), "8");
     assert_eq!(f.fractional_part(), Some("2"));
     assert_eq!(f.exponent_part(), "e-_04_9");
-    assert_eq!(f.type_suffix(), Some(FloatType::F64));
+    assert_eq!(FloatType::from_suffix(f.suffix()), Some(FloatType::F64));
 
     Ok(())
 }
@@ -125,7 +125,6 @@ fn simple() {
     check!("3" ".14" "" f32);
     check!("3" ".14" "" f64);
 
-    check!("3" "" "" f32);
     check!("3" "" "e987654321" -);
     check!("3" "" "e987654321" f64);
 
@@ -158,6 +157,47 @@ fn simple() {
 }
 
 #[test]
+fn non_standard_suffixes() {
+    #[track_caller]
+    fn check_suffix(
+        input: &str,
+        integer_part: &str,
+        fractional_part: Option<&str>,
+        exponent_part: &str,
+        suffix: &str,
+    ) {
+        let lit = FloatLit::parse(input)
+            .unwrap_or_else(|e| panic!("expected to parse '{}' but got {}", input, e));
+        assert_eq!(lit.integer_part(), integer_part);
+        assert_eq!(lit.fractional_part(), fractional_part);
+        assert_eq!(lit.exponent_part(), exponent_part);
+        assert_eq!(lit.suffix(), suffix);
+
+        let lit = match Literal::parse(input) {
+            Ok(Literal::Float(f)) => f,
+            other => panic!("Expected float literal, but got {:?} for '{}'", other, input),
+        };
+        assert_eq!(lit.integer_part(), integer_part);
+        assert_eq!(lit.fractional_part(), fractional_part);
+        assert_eq!(lit.exponent_part(), exponent_part);
+        assert_eq!(lit.suffix(), suffix);
+    }
+
+    check_suffix("7.1f23", "7", Some("1"), "", "f23");
+    check_suffix("7.1f320", "7", Some("1"), "", "f320");
+    check_suffix("7.1f64_", "7", Some("1"), "", "f64_");
+    check_suffix("8.1f649", "8", Some("1"), "", "f649");
+    check_suffix("8.1f64f32", "8", Some("1"), "", "f64f32");
+    check_suffix("23e2_banana", "23", None, "e2_", "banana");
+    check_suffix("23.2_banana", "23", Some("2_"), "", "banana");
+    check_suffix("23e2pe55ter", "23", None, "e2", "pe55ter");
+    check_suffix("23e2p_e55ter", "23", None, "e2", "p_e55ter");
+    check_suffix("3.15Jürgen", "3", Some("15"), "", "Jürgen");
+    check_suffix("3e2e5", "3", None, "e2", "e5");
+    check_suffix("3e2e5f", "3", None, "e2", "e5f");
+}
+
+#[test]
 fn parse_err() {
     assert_err!(FloatLit, "", Empty, None);
     assert_err_single!(FloatLit::parse("."), DoesNotStartWithDigit, 0);
@@ -176,10 +216,11 @@ fn parse_err() {
 
     assert_err_single!(FloatLit::parse("_2.7"), DoesNotStartWithDigit, 0);
     assert_err_single!(FloatLit::parse(".5"), DoesNotStartWithDigit, 0);
-    assert_err_single!(FloatLit::parse("0x44.5"), InvalidFloatTypeSuffix, 1..6);
     assert_err!(FloatLit, "1e", NoExponentDigits, 1..2);
     assert_err!(FloatLit, "1.e4", UnexpectedChar, 2);
     assert_err!(FloatLit, "3._4", UnexpectedChar, 2);
+    assert_err!(FloatLit, "3.f32", UnexpectedChar, 2);
+    assert_err!(FloatLit, "3.e5", UnexpectedChar, 2);
     assert_err!(FloatLit, "12345._987", UnexpectedChar, 6);
     assert_err!(FloatLit, "46._", UnexpectedChar, 3);
     assert_err!(FloatLit, "46.f32", UnexpectedChar, 3);
@@ -188,19 +229,25 @@ fn parse_err() {
     assert_err!(FloatLit, "46.e3f64", UnexpectedChar, 3);
     assert_err!(FloatLit, "23.4e_", NoExponentDigits, 4..6);
     assert_err!(FloatLit, "23E___f32", NoExponentDigits, 2..6);
-    assert_err!(FloatLit, "7f23", InvalidFloatTypeSuffix, 1..4);
-    assert_err!(FloatLit, "7f320", InvalidFloatTypeSuffix, 1..5);
-    assert_err!(FloatLit, "7f64_", InvalidFloatTypeSuffix, 1..5);
-    assert_err!(FloatLit, "8f649", InvalidFloatTypeSuffix, 1..5);
-    assert_err!(FloatLit, "8f64f32", InvalidFloatTypeSuffix, 1..7);
-    assert_err!(FloatLit, "55e3.1", InvalidFloatTypeSuffix, 4..6);  // suboptimal
+    assert_err!(FloatLit, "55e3.1", UnexpectedChar, 4..6);
 
-    assert_err!(FloatLit, "3.7+", InvalidFloatTypeSuffix, 3..4);
-    assert_err!(FloatLit, "3.7+2", InvalidFloatTypeSuffix, 3..5);
-    assert_err!(FloatLit, "3.7-", InvalidFloatTypeSuffix, 3..4);
-    assert_err!(FloatLit, "3.7-2", InvalidFloatTypeSuffix, 3..5);
+    assert_err!(FloatLit, "3.7+", UnexpectedChar, 3..4);
+    assert_err!(FloatLit, "3.7+2", UnexpectedChar, 3..5);
+    assert_err!(FloatLit, "3.7-", UnexpectedChar, 3..4);
+    assert_err!(FloatLit, "3.7-2", UnexpectedChar, 3..5);
     assert_err!(FloatLit, "3.7e+", NoExponentDigits, 3..5);
     assert_err!(FloatLit, "3.7e-", NoExponentDigits, 3..5);
-    assert_err!(FloatLit, "3.7e-+3", NoExponentDigits, 3..5);  // suboptimal
-    assert_err!(FloatLit, "3.7e+-3", NoExponentDigits, 3..5);  // suboptimal
+    assert_err!(FloatLit, "3.7e-+3", NoExponentDigits, 3..5);  // suboptimal error
+    assert_err!(FloatLit, "3.7e+-3", NoExponentDigits, 3..5);  // suboptimal error
+    assert_err_single!(FloatLit::parse("0x44.5"), InvalidSuffix, 1..6);
+
+    assert_err_single!(FloatLit::parse("3"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("35_389"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("9_8_7f32"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("9_8_7banana"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("7f23"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("7f320"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("7f64_"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("8f649"), UnexpectedIntegerLit, None);
+    assert_err_single!(FloatLit::parse("8f64f32"), UnexpectedIntegerLit, None);
 }

--- a/src/integer/mod.rs
+++ b/src/integer/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 use crate::{
     Buffer, ParseError,
@@ -42,37 +42,6 @@ pub enum IntegerBase {
     Decimal,
     Hexadecimal,
 }
-
-/// All possible integer type suffixes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IntegerType {
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    Usize,
-    I8,
-    I16,
-    I32,
-    I64,
-    I128,
-    Isize,
-}
-
-impl IntegerBase {
-    /// Returns the literal prefix that indicates this base, i.e. `"0b"`,
-    /// `"0o"`, `""` and `"0x"`.
-    pub fn prefix(self) -> &'static str {
-        match self {
-            Self::Binary => "0b",
-            Self::Octal => "0o",
-            Self::Decimal => "",
-            Self::Hexadecimal => "0x",
-        }
-    }
-}
-
 impl<B: Buffer> IntegerLit<B> {
     /// Parses the input as an integer literal. Returns an error if the input is
     /// invalid or represents a different kind of literal.
@@ -299,6 +268,79 @@ pub(crate) fn parse_impl(input: &str, first: u8) -> Result<IntegerLit<&str>, Par
         base,
         type_suffix,
     })
+}
+
+
+
+/// All possible integer type suffixes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntegerType {
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    Usize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    Isize,
+}
+
+impl IntegerType {
+    /// Returns the type corresponding to the given suffix (e.g. `"u8"` is
+    /// mapped to `Self::U8`). If the suffix is not a valid integer type,
+    /// `None` is returned.
+    pub fn from_suffix(suffix: &str) -> Option<Self> {
+        match suffix {
+            "u8" => Some(Self::U8),
+            "u16" => Some(Self::U16),
+            "u32" => Some(Self::U32),
+            "u64" => Some(Self::U64),
+            "u128" => Some(Self::U128),
+            "usize" => Some(Self::Usize),
+            "i8" => Some(Self::I8),
+            "i16" => Some(Self::I16),
+            "i32" => Some(Self::I32),
+            "i64" => Some(Self::I64),
+            "i128" => Some(Self::I128),
+            "isize" => Some(Self::Isize),
+            _ => None,
+        }
+    }
+
+    /// Returns the suffix for this type, e.g. `"u8"` for `Self::U8`.
+    pub fn suffix(self) -> &'static str {
+        match self {
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::U128 => "u128",
+            Self::Usize => "usize",
+            Self::I8 => "i8",
+            Self::I16 => "i16",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::I128 => "i128",
+            Self::Isize => "isize",
+        }
+    }
+}
+
+impl FromStr for IntegerType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_suffix(s).ok_or(())
+    }
+}
+
+impl fmt::Display for IntegerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.suffix().fmt(f)
+    }
 }
 
 

--- a/src/integer/mod.rs
+++ b/src/integer/mod.rs
@@ -34,14 +34,6 @@ pub struct IntegerLit<B: Buffer> {
     type_suffix: Option<IntegerType>,
 }
 
-/// The bases in which an integer can be specified.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IntegerBase {
-    Binary,
-    Octal,
-    Decimal,
-    Hexadecimal,
-}
 impl<B: Buffer> IntegerLit<B> {
     /// Parses the input as an integer literal. Returns an error if the input is
     /// invalid or represents a different kind of literal.
@@ -75,12 +67,7 @@ impl<B: Buffer> IntegerLit<B> {
     ///
     /// Returns `None` if the literal overflows `N`.
     pub fn value<N: FromIntegerLiteral>(&self) -> Option<N> {
-        let base = match self.base {
-            IntegerBase::Binary => N::from_small_number(2),
-            IntegerBase::Octal => N::from_small_number(8),
-            IntegerBase::Decimal => N::from_small_number(10),
-            IntegerBase::Hexadecimal => N::from_small_number(16),
-        };
+        let base = N::from_small_number(self.base.value());
 
         let mut acc = N::from_small_number(0);
         for digit in self.raw_main_part().bytes() {
@@ -271,6 +258,37 @@ pub(crate) fn parse_impl(input: &str, first: u8) -> Result<IntegerLit<&str>, Par
 }
 
 
+/// The bases in which an integer can be specified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntegerBase {
+    Binary,
+    Octal,
+    Decimal,
+    Hexadecimal,
+}
+
+impl IntegerBase {
+    /// Returns the literal prefix that indicates this base, i.e. `"0b"`,
+    /// `"0o"`, `""` and `"0x"`.
+    pub fn prefix(self) -> &'static str {
+        match self {
+            Self::Binary => "0b",
+            Self::Octal => "0o",
+            Self::Decimal => "",
+            Self::Hexadecimal => "0x",
+        }
+    }
+
+    /// Returns the base value, i.e. 2, 8, 10 or 16.
+    pub fn value(self) -> u8 {
+        match self {
+            Self::Binary => 2,
+            Self::Octal => 8,
+            Self::Decimal => 10,
+            Self::Hexadecimal => 16,
+        }
+    }
+}
 
 /// All possible integer type suffixes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //! // Parse a specific kind of literal (float in this case):
 //! let float_lit = FloatLit::parse("3.14f32");
 //! assert!(float_lit.is_ok());
-//! assert_eq!(float_lit.unwrap().type_suffix(), Some(litrs::FloatType::F32));
+//! assert_eq!(float_lit.unwrap().suffix(), "f32");
 //! assert!(FloatLit::parse("'c'").is_err());
 //!
 //! // Parse any kind of literal. After parsing, you can inspect the literal
@@ -105,6 +105,11 @@
 //!
 //! - `proc-macro2` (**default**): adds the dependency `proc_macro2`, a bunch of
 //!   `From` and `TryFrom` impls, and [`InvalidToken::to_compile_error2`].
+//! - `check_suffix`: if enabled, `parse` functions will exactly verify that the
+//!   literal suffix is valid. Adds the dependency `unicode-xid`. If disabled,
+//!   only an approximate check (only in ASCII range) is done. If you are
+//!   writing a proc macro, you don't need to enable this as the suffix is
+//!   already checked by the compiler.
 //!
 //!
 //! [ref]: https://doc.rust-lang.org/reference/tokens.html#literals

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,11 @@ pub enum Literal<B: Buffer> {
 }
 
 impl<B: Buffer> Literal<B> {
+    /// Parses the given input as a Rust literal.
+    pub fn parse(input: B) -> Result<Self, ParseError> {
+        parse::parse(input)
+    }
+
     /// Returns the suffix of this literal or `""` if it doesn't have one.
     ///
     /// Rust token grammar actually allows suffixes for all kinds of tokens.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -42,11 +42,11 @@ impl<B: Buffer> Literal<B> {
             },
 
             b'\'' => CharLit::parse(input).map(Literal::Char),
-            b'"' | b'r' => StringLit::parse_impl(input).map(Literal::String),
+            b'"' | b'r' => StringLit::parse(input).map(Literal::String),
 
             b'b' if second == Some(b'\'') => ByteLit::parse(input).map(Literal::Byte),
             b'b' if second == Some(b'r') || second == Some(b'"')
-                => ByteStringLit::parse_impl(input).map(Literal::ByteString),
+                => ByteStringLit::parse(input).map(Literal::ByteString),
 
             _ => Err(perr(None, InvalidLiteral)),
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -9,7 +9,7 @@ use crate::{
     IntegerLit,
     Literal,
     StringLit,
-    err::{perr, ParseErrorKind::*},
+    err::{perr, ParseErrorKind::{*, self}},
 };
 
 
@@ -30,19 +30,14 @@ impl<B: Buffer> Literal<B> {
                 // work with what is happening in the integer/float parse
                 // methods, but it makes the code way easier for now and won't
                 // be a huge performance loss.
-                let end = 1 + end_dec_digits(rest);
-                match input.as_bytes().get(end) {
-                    // Potential chars in integer literals: b, o, x for base; u
-                    // and i for type suffix.
-                    None | Some(b'b') | Some(b'o') | Some(b'x') | Some(b'u') | Some(b'i')
-                        => IntegerLit::parse(input).map(Literal::Integer),
-
-                    // Potential chars for float literals: `.` as fractional
-                    // period, e and E as exponent start and f as type suffix.
-                    Some(b'.') | Some(b'e') | Some(b'E') | Some(b'f')
+                //
+                // The first non-decimal char in a float literal must
+                // be '.', 'e' or 'E'.
+                match input.as_bytes().get(1 + end_dec_digits(rest)) {
+                    Some(b'.') | Some(b'e') | Some(b'E')
                         => FloatLit::parse(input).map(Literal::Float),
 
-                    _ => Err(perr(end, UnexpectedChar)),
+                    _ => IntegerLit::parse(input).map(Literal::Integer),
                 }
             },
 
@@ -79,3 +74,56 @@ pub(crate) fn hex_digit_value(digit: u8) -> Option<u8> {
         _ => None,
     }
 }
+
+/// Makes sure that `s` is a valid literal suffix.
+pub(crate) fn check_suffix(s: &str) -> Result<(), ParseErrorKind> {
+    if s.is_empty() {
+        return Ok(());
+    }
+
+    let mut chars = s.chars();
+    let first = chars.next().unwrap();
+    let rest = chars.as_str();
+    if first == '_' && rest.is_empty() {
+        return Err(InvalidSuffix);
+    }
+
+    // This is just an extra check to improve the error message. If the first
+    // character of the "suffix" is already some invalid ASCII
+    // char, "unexpected character" seems like the more fitting error.
+    if first.is_ascii() && !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(UnexpectedChar);
+    }
+
+    // Proper check is optional as it's not really necessary in proc macro
+    // context.
+    #[cfg(feature = "check_suffix")]
+    fn is_valid_suffix(first: char, rest: &str) -> bool {
+        use unicode_xid::UnicodeXID;
+
+        (first == '_' || first.is_xid_start())
+            && rest.chars().all(|c| c.is_xid_continue())
+    }
+
+    // When avoiding the dependency on `unicode_xid`, we just do a best effort
+    // to catch the most common errors.
+    #[cfg(not(feature = "check_suffix"))]
+    fn is_valid_suffix(first: char, rest: &str) -> bool {
+        if first.is_ascii() && !(first.is_ascii_alphabetic() || first == '_') {
+            return false;
+        }
+        for c in rest.chars() {
+            if c.is_ascii() && !(c.is_ascii_alphanumeric() || c == '_') {
+                return false;
+            }
+        }
+        true
+    }
+
+    if is_valid_suffix(first, rest) {
+        Ok(())
+    } else {
+        Err(InvalidSuffix)
+    }
+}
+

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -123,4 +123,3 @@ pub(crate) fn check_suffix(s: &str) -> Result<(), ParseErrorKind> {
         Err(InvalidSuffix)
     }
 }
-

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,25 +25,16 @@ fn invalid_literals() {
 
 #[test]
 fn misc() {
-    assert_err_single!(Literal::parse("0x44.5"), InvalidIntegerTypeSuffix, 4..6);
+    assert_err_single!(Literal::parse("0x44.5"), UnexpectedChar, 4..6);
     assert_err_single!(Literal::parse("a"), InvalidLiteral, None);
     assert_err_single!(Literal::parse(";"), InvalidLiteral, None);
     assert_err_single!(Literal::parse("0;"), UnexpectedChar, 1);
-    assert_err_single!(Literal::parse("0a"), UnexpectedChar, 1);
-    assert_err_single!(Literal::parse("0z"), UnexpectedChar, 1);
     assert_err_single!(Literal::parse(" 0"), InvalidLiteral, None);
     assert_err_single!(Literal::parse("0 "), UnexpectedChar, 1);
-    assert_err_single!(Literal::parse("0a3"), UnexpectedChar, 1);
-    assert_err_single!(Literal::parse("0z3"), UnexpectedChar, 1);
     assert_err_single!(Literal::parse("_"), InvalidLiteral, None);
     assert_err_single!(Literal::parse("_3"), InvalidLiteral, None);
-    assert_err_single!(Literal::parse("12a3"), UnexpectedChar, 2);
-    assert_err_single!(Literal::parse("12f3"), InvalidFloatTypeSuffix, 2..4);
-    assert_err_single!(Literal::parse("12f_"), InvalidFloatTypeSuffix, 2..4);
-    assert_err_single!(Literal::parse("12F_"), UnexpectedChar, 2);
     assert_err_single!(Literal::parse("a_123"), InvalidLiteral, None);
     assert_err_single!(Literal::parse("B_123"), InvalidLiteral, None);
-    assert_err_single!(Literal::parse("54321a64"), UnexpectedChar, 5);
 }
 
 macro_rules! assert_no_panic {


### PR DESCRIPTION
Closes #2

Quite a few breaking changes due to this change. This should fix the last known difference between litrs and the Rust compiler.