### PR TITLE
Add quote integration as optional printing feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litrs"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 edition = "2018"
 rust-version = "1.54"
@@ -25,9 +25,11 @@ exclude = [".github"]
 
 
 [features]
-default = ["proc-macro2"]
+default = ["proc-macro2", "printing"]
 check_suffix = ["unicode-xid"]
+printing = ["dep:quote"]
 
 [dependencies]
-proc-macro2 = { version = "1", optional = true }
+proc-macro2 = { version = "1",     optional = true }
 unicode-xid = { version = "0.2.4", optional = true }
+quote       = { version = "1",     optional = true, no-default-features = true }

--- a/src/bool/mod.rs
+++ b/src/bool/mod.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 
-use crate::{ParseError, err::{perr, ParseErrorKind::*}};
-
+use crate::{
+    err::{perr, ParseErrorKind::*},
+    ParseError,
+};
 
 /// A bool literal: `true` or `false`. Also see [the reference][ref].
 ///
@@ -49,7 +51,6 @@ impl fmt::Display for BoolLit {
         f.pad(self.as_str())
     }
 }
-
 
 #[cfg(test)]
 mod tests;

--- a/src/bool/tests.rs
+++ b/src/bool/tests.rs
@@ -1,17 +1,16 @@
-use crate::{
-    Literal, BoolLit,
-    test_util::assert_parse_ok_eq,
-};
+use crate::{test_util::assert_parse_ok_eq, BoolLit, Literal};
 
 macro_rules! assert_bool_parse {
     ($input:literal, $expected:expr) => {
         assert_parse_ok_eq(
-            $input, Literal::parse($input), Literal::Bool($expected), "Literal::parse");
+            $input,
+            Literal::parse($input),
+            Literal::Bool($expected),
+            "Literal::parse",
+        );
         assert_parse_ok_eq($input, BoolLit::parse($input), $expected, "BoolLit::parse");
     };
 }
-
-
 
 #[test]
 fn parse_ok() {

--- a/src/byte/mod.rs
+++ b/src/byte/mod.rs
@@ -1,12 +1,11 @@
 use core::fmt;
 
 use crate::{
-    Buffer, ParseError,
     err::{perr, ParseErrorKind::*},
     escape::unescape,
     parse::check_suffix,
+    Buffer, ParseError,
 };
-
 
 /// A (single) byte literal, e.g. `b'k'` or `b'!'`.
 ///
@@ -33,7 +32,11 @@ impl<B: Buffer> ByteLit<B> {
         }
 
         let (value, start_suffix) = parse_impl(&input)?;
-        Ok(Self { raw: input, value, start_suffix })
+        Ok(Self {
+            raw: input,
+            value,
+            start_suffix,
+        })
     }
 
     /// Returns the byte value that this literal represents.
@@ -55,7 +58,6 @@ impl<B: Buffer> ByteLit<B> {
     pub fn into_raw_input(self) -> B {
         self.raw
     }
-
 }
 
 impl ByteLit<&str> {
@@ -80,7 +82,9 @@ impl<B: Buffer> fmt::Display for ByteLit<B> {
 #[inline(never)]
 pub(crate) fn parse_impl(input: &str) -> Result<(u8, usize), ParseError> {
     let input_bytes = input.as_bytes();
-    let first = input_bytes.get(2).ok_or(perr(None, UnterminatedByteLiteral))?;
+    let first = input_bytes
+        .get(2)
+        .ok_or(perr(None, UnterminatedByteLiteral))?;
     let (c, len) = match first {
         b'\'' if input_bytes.get(3) == Some(&b'\'') => return Err(perr(2, UnescapedSingleQuote)),
         b'\'' => return Err(perr(None, EmptyByteLiteral)),

--- a/src/byte/tests.rs
+++ b/src/byte/tests.rs
@@ -1,9 +1,14 @@
-use crate::{ByteLit, Literal, test_util::{assert_parse_ok_eq, assert_roundtrip}};
+use crate::{
+    test_util::{assert_parse_ok_eq, assert_roundtrip},
+    ByteLit, Literal,
+};
 
 // ===== Utility functions =======================================================================
 
 macro_rules! check {
-    ($lit:literal) => { check!($lit, stringify!($lit), "") };
+    ($lit:literal) => {
+        check!($lit, stringify!($lit), "")
+    };
     ($lit:literal, $input:expr, $suffix:literal) => {
         let input = $input;
         let expected = ByteLit {
@@ -12,15 +17,24 @@ macro_rules! check {
             value: $lit,
         };
 
-        assert_parse_ok_eq(input, ByteLit::parse(input), expected.clone(), "ByteLit::parse");
-        assert_parse_ok_eq(input, Literal::parse(input), Literal::Byte(expected), "Literal::parse");
+        assert_parse_ok_eq(
+            input,
+            ByteLit::parse(input),
+            expected.clone(),
+            "ByteLit::parse",
+        );
+        assert_parse_ok_eq(
+            input,
+            Literal::parse(input),
+            Literal::Byte(expected),
+            "Literal::parse",
+        );
         let lit = ByteLit::parse(input).unwrap();
         assert_eq!(lit.value(), $lit);
         assert_eq!(lit.suffix(), $suffix);
         assert_roundtrip(expected.to_owned(), input);
     };
 }
-
 
 // ===== Actual tests ============================================================================
 

--- a/src/bytestr/mod.rs
+++ b/src/bytestr/mod.rs
@@ -1,11 +1,10 @@
 use std::{fmt, ops::Range};
 
 use crate::{
-    Buffer, ParseError,
     err::{perr, ParseErrorKind::*},
     escape::{scan_raw_string, unescape_string},
+    Buffer, ParseError,
 };
-
 
 /// A byte string or raw byte string literal, e.g. `b"hello"` or `br#"abc"def"#`.
 ///
@@ -41,13 +40,20 @@ impl<B: Buffer> ByteStringLit<B> {
         }
 
         let (value, num_hashes, start_suffix) = parse_impl(&input)?;
-        Ok(Self { raw: input, value, num_hashes, start_suffix })
+        Ok(Self {
+            raw: input,
+            value,
+            num_hashes,
+            start_suffix,
+        })
     }
 
     /// Returns the string value this literal represents (where all escapes have
     /// been turned into their respective values).
     pub fn value(&self) -> &[u8] {
-        self.value.as_deref().unwrap_or(&self.raw.as_bytes()[self.inner_range()])
+        self.value
+            .as_deref()
+            .unwrap_or(&self.raw.as_bytes()[self.inner_range()])
     }
 
     /// Like `value` but returns a potentially owned version of the value.
@@ -57,7 +63,9 @@ impl<B: Buffer> ByteStringLit<B> {
     pub fn into_value(self) -> B::ByteCow {
         let inner_range = self.inner_range();
         let Self { raw, value, .. } = self;
-        value.map(B::ByteCow::from).unwrap_or_else(|| raw.cut(inner_range).into_byte_cow())
+        value
+            .map(B::ByteCow::from)
+            .unwrap_or_else(|| raw.cut(inner_range).into_byte_cow())
     }
 
     /// The optional suffix. Returns `""` if the suffix is empty/does not exist.
@@ -108,7 +116,6 @@ impl<B: Buffer> fmt::Display for ByteStringLit<B> {
         f.pad(&self.raw)
     }
 }
-
 
 /// Precondition: input has to start with either `b"` or `br`.
 #[inline(never)]

--- a/src/char/tests.rs
+++ b/src/char/tests.rs
@@ -1,10 +1,15 @@
-use crate::{Literal, test_util::{assert_parse_ok_eq, assert_roundtrip}};
 use super::CharLit;
+use crate::{
+    test_util::{assert_parse_ok_eq, assert_roundtrip},
+    Literal,
+};
 
 // ===== Utility functions =======================================================================
 
 macro_rules! check {
-    ($lit:literal) => { check!($lit, stringify!($lit), "") };
+    ($lit:literal) => {
+        check!($lit, stringify!($lit), "")
+    };
     ($lit:literal, $input:expr, $suffix:literal) => {
         let input = $input;
         let expected = CharLit {
@@ -13,15 +18,24 @@ macro_rules! check {
             value: $lit,
         };
 
-        assert_parse_ok_eq(input, CharLit::parse(input), expected.clone(), "CharLit::parse");
-        assert_parse_ok_eq(input, Literal::parse(input), Literal::Char(expected), "Literal::parse");
+        assert_parse_ok_eq(
+            input,
+            CharLit::parse(input),
+            expected.clone(),
+            "CharLit::parse",
+        );
+        assert_parse_ok_eq(
+            input,
+            Literal::parse(input),
+            Literal::Char(expected),
+            "Literal::parse",
+        );
         let lit = CharLit::parse(input).unwrap();
         assert_eq!(lit.value(), $lit);
         assert_eq!(lit.suffix(), $suffix);
         assert_roundtrip(expected.to_owned(), input);
     };
 }
-
 
 // ===== Actual tests ============================================================================
 
@@ -196,7 +210,12 @@ fn invalid_unicode_escapes() {
 
     assert_err!(CharLit, r"'\u{1234567}'", TooManyDigitInUnicodeEscape, 10);
     assert_err!(CharLit, r"'\u{1234567}'", TooManyDigitInUnicodeEscape, 10);
-    assert_err!(CharLit, r"'\u{1_23_4_56_7}'", TooManyDigitInUnicodeEscape, 14);
+    assert_err!(
+        CharLit,
+        r"'\u{1_23_4_56_7}'",
+        TooManyDigitInUnicodeEscape,
+        14
+    );
     assert_err!(CharLit, r"'\u{abcdef123}'", TooManyDigitInUnicodeEscape, 10);
 
     assert_err!(CharLit, r"'\u{110000}'", InvalidUnicodeEscapeChar, 1..10);

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,6 +1,5 @@
 use std::{fmt, ops::Range};
 
-
 /// An error signaling that a different kind of token was expected. Returned by
 /// the various `TryFrom` impls.
 #[derive(Debug, Clone, Copy)]
@@ -15,7 +14,7 @@ impl InvalidToken {
     /// `"msg"` is the output of `self.to_string()`. **Panics if called outside
     /// of a proc-macro context!**
     pub fn to_compile_error(&self) -> proc_macro::TokenStream {
-        use proc_macro::{Delimiter, Ident, Group, Punct, Spacing, TokenTree};
+        use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, TokenTree};
 
         let span = match self.span {
             Span::One(s) => s,
@@ -32,8 +31,13 @@ impl InvalidToken {
             )),
         ];
 
-
-        tokens.into_iter().map(|mut t| { t.set_span(span); t }).collect()
+        tokens
+            .into_iter()
+            .map(|mut t| {
+                t.set_span(span);
+                t
+            })
+            .collect()
     }
 
     /// Like [`to_compile_error`][Self::to_compile_error], but returns a token
@@ -41,7 +45,7 @@ impl InvalidToken {
     /// context.
     #[cfg(feature = "proc-macro2")]
     pub fn to_compile_error2(&self) -> proc_macro2::TokenStream {
-        use proc_macro2::{Delimiter, Ident, Group, Punct, Spacing, TokenTree};
+        use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, TokenTree};
 
         let span = match self.span {
             Span::One(s) => proc_macro2::Span::from(s),
@@ -57,8 +61,13 @@ impl InvalidToken {
             )),
         ];
 
-
-        tokens.into_iter().map(|mut t| { t.set_span(span); t }).collect()
+        tokens
+            .into_iter()
+            .map(|mut t| {
+                t.set_span(span);
+                t
+            })
+            .collect()
     }
 }
 
@@ -82,7 +91,12 @@ impl fmt::Display for InvalidToken {
             }
         }
 
-        write!(f, "expected {}, but found {}", kind_desc(self.expected), kind_desc(self.actual))
+        write!(
+            f,
+            "expected {}, but found {}",
+            kind_desc(self.expected),
+            kind_desc(self.actual)
+        )
     }
 }
 
@@ -197,7 +211,6 @@ impl SpanLike for usize {
         Some(self..self + 1)
     }
 }
-
 
 /// Kinds of errors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,12 +1,10 @@
 use std::{fmt, str::FromStr};
 
 use crate::{
-    Buffer, ParseError,
     err::{perr, ParseErrorKind::*},
-    parse::{end_dec_digits, first_byte_or_empty, check_suffix},
+    parse::{check_suffix, end_dec_digits, first_byte_or_empty},
+    Buffer, ParseError,
 };
-
-
 
 /// A floating point literal, e.g. `3.14`, `8.`, `135e12`, `27f32` or `1.956e2f64`.
 ///
@@ -70,8 +68,13 @@ impl<B: Buffer> FloatLit<B> {
                     ..
                 } = parse_impl(&s)?;
 
-                Ok(Self { raw: s, end_integer_part, end_fractional_part, end_number_part })
-            },
+                Ok(Self {
+                    raw: s,
+                    end_integer_part,
+                    end_fractional_part,
+                    end_number_part,
+                })
+            }
             _ => Err(perr(0, DoesNotStartWithDigit)),
         }
     }
@@ -148,7 +151,6 @@ pub(crate) fn parse_impl(input: &str) -> Result<FloatLit<&str>, ParseError> {
     let end_integer_part = end_dec_digits(input.as_bytes());
     let rest = &input[end_integer_part..];
 
-
     // Fractional part.
     let end_fractional_part = if rest.as_bytes().get(0) == Some(&b'.') {
         // The fractional part must not start with `_`.
@@ -178,7 +180,10 @@ pub(crate) fn parse_impl(input: &str) -> Result<FloatLit<&str>, ParseError> {
 
         // Find end of exponent and make sure there is at least one digit.
         let end_exponent = end_dec_digits(rest[exp_number_start..].as_bytes()) + exp_number_start;
-        if !rest[exp_number_start..end_exponent].bytes().any(|b| matches!(b, b'0'..=b'9')) {
+        if !rest[exp_number_start..end_exponent]
+            .bytes()
+            .any(|b| matches!(b, b'0'..=b'9'))
+        {
             return Err(perr(
                 end_fractional_part..end_fractional_part + end_exponent,
                 NoExponentDigits,
@@ -207,7 +212,6 @@ pub(crate) fn parse_impl(input: &str) -> Result<FloatLit<&str>, ParseError> {
         end_number_part,
     })
 }
-
 
 /// All possible float type suffixes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -250,7 +254,6 @@ impl fmt::Display for FloatType {
         self.suffix().fmt(f)
     }
 }
-
 
 #[cfg(test)]
 mod tests;

--- a/src/float/tests.rs
+++ b/src/float/tests.rs
@@ -1,9 +1,8 @@
-use crate::{
-    Literal, ParseError,
-    test_util::{assert_parse_ok_eq, assert_roundtrip},
-};
 use super::{FloatLit, FloatType};
-
+use crate::{
+    test_util::{assert_parse_ok_eq, assert_roundtrip},
+    Literal, ParseError,
+};
 
 // ===== Utility functions =======================================================================
 
@@ -35,7 +34,6 @@ macro_rules! check {
     (@stringify_suffix -) => { "" };
     (@stringify_suffix $suffix:ident) => { stringify!($suffix) };
 }
-
 
 // ===== Actual tests ===========================================================================
 
@@ -175,7 +173,10 @@ fn non_standard_suffixes() {
 
         let lit = match Literal::parse(input) {
             Ok(Literal::Float(f)) => f,
-            other => panic!("Expected float literal, but got {:?} for '{}'", other, input),
+            other => panic!(
+                "Expected float literal, but got {:?} for '{}'",
+                other, input
+            ),
         };
         assert_eq!(lit.integer_part(), integer_part);
         assert_eq!(lit.fractional_part(), fractional_part);
@@ -237,8 +238,8 @@ fn parse_err() {
     assert_err!(FloatLit, "3.7-2", UnexpectedChar, 3..5);
     assert_err!(FloatLit, "3.7e+", NoExponentDigits, 3..5);
     assert_err!(FloatLit, "3.7e-", NoExponentDigits, 3..5);
-    assert_err!(FloatLit, "3.7e-+3", NoExponentDigits, 3..5);  // suboptimal error
-    assert_err!(FloatLit, "3.7e+-3", NoExponentDigits, 3..5);  // suboptimal error
+    assert_err!(FloatLit, "3.7e-+3", NoExponentDigits, 3..5); // suboptimal error
+    assert_err!(FloatLit, "3.7e+-3", NoExponentDigits, 3..5); // suboptimal error
     assert_err_single!(FloatLit::parse("0x44.5"), InvalidSuffix, 1..6);
 
     assert_err_single!(FloatLit::parse("3"), UnexpectedIntegerLit, None);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,7 +1,9 @@
 use std::convert::TryFrom;
 
-use crate::{Literal, err::{InvalidToken, TokenKind}};
-
+use crate::{
+    err::{InvalidToken, TokenKind},
+    Literal,
+};
 
 /// Helper macro to call a `callback` macro four times for all combinations of
 /// `proc_macro`/`proc_macro2` and `&`/owned.
@@ -25,7 +27,6 @@ macro_rules! helper_no_refs {
     };
 }
 
-
 // ==============================================================================================
 // ===== `From<*Lit> for Literal`
 // ==============================================================================================
@@ -48,12 +49,9 @@ impl_specific_lit_to_lit!(crate::StringLit<B>, String);
 impl_specific_lit_to_lit!(crate::ByteLit<B>, Byte);
 impl_specific_lit_to_lit!(crate::ByteStringLit<B>, ByteString);
 
-
-
 // ==============================================================================================
 // ===== `From<pm::Literal> for Literal`
 // ==============================================================================================
-
 
 macro_rules! impl_tt_to_lit {
     ([$($prefix:tt)*] => ) => {
@@ -69,8 +67,7 @@ macro_rules! impl_tt_to_lit {
     }
 }
 
-helper!(impl_tt_to_lit, );
-
+helper!(impl_tt_to_lit,);
 
 // ==============================================================================================
 // ===== `TryFrom<pm::TokenTree> for Literal`
@@ -106,8 +103,7 @@ macro_rules! impl_tt_to_lit {
     }
 }
 
-helper!(impl_tt_to_lit, );
-
+helper!(impl_tt_to_lit,);
 
 // ==============================================================================================
 // ===== `TryFrom<pm::Literal>`, `TryFrom<pm::TokenTree>` for non-bool `*Lit`
@@ -167,13 +163,32 @@ macro_rules! impl_for_specific_lit {
     };
 }
 
-helper!(impl_for_specific_lit, crate::IntegerLit<String>, Integer, IntegerLit);
-helper!(impl_for_specific_lit, crate::FloatLit<String>, Float, FloatLit);
+helper!(
+    impl_for_specific_lit,
+    crate::IntegerLit<String>,
+    Integer,
+    IntegerLit
+);
+helper!(
+    impl_for_specific_lit,
+    crate::FloatLit<String>,
+    Float,
+    FloatLit
+);
 helper!(impl_for_specific_lit, crate::CharLit<String>, Char, CharLit);
-helper!(impl_for_specific_lit, crate::StringLit<String>, String, StringLit);
+helper!(
+    impl_for_specific_lit,
+    crate::StringLit<String>,
+    String,
+    StringLit
+);
 helper!(impl_for_specific_lit, crate::ByteLit<String>, Byte, ByteLit);
-helper!(impl_for_specific_lit, crate::ByteStringLit<String>, ByteString, ByteStringLit);
-
+helper!(
+    impl_for_specific_lit,
+    crate::ByteStringLit<String>,
+    ByteString,
+    ByteStringLit
+);
 
 // ==============================================================================================
 // ===== `From<*Lit> for pm::Literal`
@@ -204,8 +219,12 @@ helper_no_refs!(impl_specific_lit_to_pm_lit, FloatLit, Float, FloatLit);
 helper_no_refs!(impl_specific_lit_to_pm_lit, CharLit, Char, CharLit);
 helper_no_refs!(impl_specific_lit_to_pm_lit, StringLit, String, StringLit);
 helper_no_refs!(impl_specific_lit_to_pm_lit, ByteLit, Byte, ByteLit);
-helper_no_refs!(impl_specific_lit_to_pm_lit, ByteStringLit, ByteString, ByteStringLit);
-
+helper_no_refs!(
+    impl_specific_lit_to_pm_lit,
+    ByteStringLit,
+    ByteString,
+    ByteStringLit
+);
 
 // ==============================================================================================
 // ===== `TryFrom<pm::TokenTree> for BoolLit`
@@ -239,7 +258,7 @@ macro_rules! impl_from_tt_for_bool {
     };
 }
 
-helper!(impl_from_tt_for_bool, );
+helper!(impl_from_tt_for_bool,);
 
 // ==============================================================================================
 // ===== `From<BoolLit> for pm::Ident`
@@ -255,8 +274,7 @@ macro_rules! impl_bool_lit_to_pm_lit {
     };
 }
 
-helper_no_refs!(impl_bool_lit_to_pm_lit, );
-
+helper_no_refs!(impl_bool_lit_to_pm_lit,);
 
 mod tests {
     //! # Tests

--- a/src/integer/mod.rs
+++ b/src/integer/mod.rs
@@ -1,11 +1,10 @@
 use std::{fmt, str::FromStr};
 
 use crate::{
-    Buffer, ParseError,
     err::{perr, ParseErrorKind::*},
-    parse::{first_byte_or_empty, hex_digit_value, check_suffix},
+    parse::{check_suffix, first_byte_or_empty, hex_digit_value},
+    Buffer, ParseError,
 };
-
 
 /// An integer literal, e.g. `27`, `0x7F`, `0b101010u8` or `5_000_000i64`.
 ///
@@ -47,10 +46,15 @@ impl<B: Buffer> IntegerLit<B> {
                     end_main_part,
                     base,
                     ..
-                } =  parse_impl(&input, digit)?;
+                } = parse_impl(&input, digit)?;
 
-                Ok(Self { raw: input, start_main_part, end_main_part, base })
-            },
+                Ok(Self {
+                    raw: input,
+                    start_main_part,
+                    end_main_part,
+                    base,
+                })
+            }
             _ => Err(perr(0, DoesNotStartWithDigit)),
         }
     }
@@ -199,7 +203,6 @@ pub(crate) fn parse_impl(input: &str, first: u8) -> Result<IntegerLit<&str>, Par
     };
     let without_prefix = &input[end_prefix..];
 
-
     // Scan input to find the first character that's not a valid digit.
     let is_valid_digit = match base {
         IntegerBase::Binary => |b| matches!(b, b'0' | b'1' | b'_'),
@@ -207,7 +210,8 @@ pub(crate) fn parse_impl(input: &str, first: u8) -> Result<IntegerLit<&str>, Par
         IntegerBase::Decimal => |b| matches!(b, b'0'..=b'9' | b'_'),
         IntegerBase::Hexadecimal => |b| matches!(b, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F' | b'_'),
     };
-    let end_main = without_prefix.bytes()
+    let end_main = without_prefix
+        .bytes()
         .position(|b| !is_valid_digit(b))
         .unwrap_or(without_prefix.len());
     let (main_part, suffix) = without_prefix.split_at(end_main);
@@ -238,7 +242,6 @@ pub(crate) fn parse_impl(input: &str, first: u8) -> Result<IntegerLit<&str>, Par
         base,
     })
 }
-
 
 /// The bases in which an integer can be specified.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -343,7 +346,6 @@ impl fmt::Display for IntegerType {
         self.suffix().fmt(f)
     }
 }
-
 
 #[cfg(test)]
 mod tests;

--- a/src/integer/tests.rs
+++ b/src/integer/tests.rs
@@ -1,9 +1,10 @@
-use std::fmt::{Debug, Display};
 use crate::{
-    FromIntegerLiteral, Literal, IntegerLit, IntegerType as Ty, IntegerBase, IntegerBase::*,
     test_util::{assert_parse_ok_eq, assert_roundtrip},
+    FromIntegerLiteral, IntegerBase,
+    IntegerBase::*,
+    IntegerLit, IntegerType as Ty, Literal,
 };
-
+use std::fmt::{Debug, Display};
 
 // ===== Utility functions =======================================================================
 
@@ -22,11 +23,22 @@ fn check<T: FromIntegerLiteral + PartialEq + Debug + Display>(
         base,
     };
     assert_parse_ok_eq(
-        input, IntegerLit::parse(input), expected_integer.clone(), "IntegerLit::parse");
+        input,
+        IntegerLit::parse(input),
+        expected_integer.clone(),
+        "IntegerLit::parse",
+    );
     assert_parse_ok_eq(
-        input, Literal::parse(input), Literal::Integer(expected_integer), "Literal::parse");
+        input,
+        Literal::parse(input),
+        Literal::Integer(expected_integer),
+        "Literal::parse",
+    );
     assert_roundtrip(expected_integer.to_owned(), input);
-    assert_eq!(Ty::from_suffix(IntegerLit::parse(input).unwrap().suffix()), type_suffix);
+    assert_eq!(
+        Ty::from_suffix(IntegerLit::parse(input).unwrap().suffix()),
+        type_suffix
+    );
 
     let actual_value = IntegerLit::parse(input)
         .unwrap()
@@ -35,13 +47,10 @@ fn check<T: FromIntegerLiteral + PartialEq + Debug + Display>(
     if actual_value != value {
         panic!(
             "Parsing int literal `{}` should give value `{}`, but actually resulted in `{}`",
-            input,
-            value,
-            actual_value,
+            input, value, actual_value,
         );
     }
 }
-
 
 // ===== Actual tests ===========================================================================
 
@@ -96,7 +105,13 @@ fn parse_binary() {
     check("0b01", 0b01, Binary, "01", None);
     check("0b101010", 0b101010, Binary, "101010", None);
     check("0b10_10_10", 0b10_10_10, Binary, "10_10_10", None);
-    check("0b01101110____", 0b01101110____, Binary, "01101110____", None);
+    check(
+        "0b01101110____",
+        0b01101110____,
+        Binary,
+        "01101110____",
+        None,
+    );
 
     check("0b10010u8", 0b10010u8, Binary, "10010", Some(Ty::U8));
     check("0b10010i8", 0b10010u8, Binary, "10010", Some(Ty::I8));
@@ -175,12 +190,42 @@ fn starting_underscore() {
 #[test]
 fn parse_overflowing_just_fine() {
     check("256u8", 256u16, Decimal, "256", Some(Ty::U8));
-    check("123_456_789u8", 123_456_789u32, Decimal, "123_456_789", Some(Ty::U8));
-    check("123_456_789u16", 123_456_789u32, Decimal, "123_456_789", Some(Ty::U16));
+    check(
+        "123_456_789u8",
+        123_456_789u32,
+        Decimal,
+        "123_456_789",
+        Some(Ty::U8),
+    );
+    check(
+        "123_456_789u16",
+        123_456_789u32,
+        Decimal,
+        "123_456_789",
+        Some(Ty::U16),
+    );
 
-    check("123_123_456_789u8", 123_123_456_789u64, Decimal, "123_123_456_789", Some(Ty::U8));
-    check("123_123_456_789u16", 123_123_456_789u64, Decimal, "123_123_456_789", Some(Ty::U16));
-    check("123_123_456_789u32", 123_123_456_789u64, Decimal, "123_123_456_789", Some(Ty::U32));
+    check(
+        "123_123_456_789u8",
+        123_123_456_789u64,
+        Decimal,
+        "123_123_456_789",
+        Some(Ty::U8),
+    );
+    check(
+        "123_123_456_789u16",
+        123_123_456_789u64,
+        Decimal,
+        "123_123_456_789",
+        Some(Ty::U16),
+    );
+    check(
+        "123_123_456_789u32",
+        123_123_456_789u64,
+        Decimal,
+        "123_123_456_789",
+        Some(Ty::U32),
+    );
 }
 
 #[test]
@@ -196,8 +241,13 @@ fn suffixes() {
         ("123u32", Ty::U32),
         ("123u64", Ty::U64),
         ("123u128", Ty::U128),
-    ].iter().for_each(|&(s, ty)| {
-        assert_eq!(Ty::from_suffix(IntegerLit::parse(s).unwrap().suffix()), Some(ty));
+    ]
+    .iter()
+    .for_each(|&(s, ty)| {
+        assert_eq!(
+            Ty::from_suffix(IntegerLit::parse(s).unwrap().suffix()),
+            Some(ty)
+        );
     });
 }
 
@@ -226,8 +276,14 @@ fn overflow_u128() {
 #[test]
 fn overflow_u8() {
     let inputs = [
-        "256", "0x100", "0o400", "0b100000000",
-        "257", "0x101", "0o401", "0b100000001",
+        "256",
+        "0x100",
+        "0o400",
+        "0b100000000",
+        "257",
+        "0x101",
+        "0o401",
+        "0b100000001",
         "300",
         "1548",
         "2548985",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,9 @@ mod test_util;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "printing")]
+mod printing;
+
 mod bool;
 mod byte;
 mod bytestr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,11 @@ mod integer;
 mod parse;
 mod string;
 
-
-use std::{borrow::{Borrow, Cow}, fmt, ops::{Deref, Range}};
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+    ops::{Deref, Range},
+};
 
 pub use self::{
     bool::BoolLit,
@@ -176,10 +179,9 @@ pub use self::{
     char::CharLit,
     err::{InvalidToken, ParseError},
     float::{FloatLit, FloatType},
-    integer::{FromIntegerLiteral, IntegerLit, IntegerBase, IntegerType},
+    integer::{FromIntegerLiteral, IntegerBase, IntegerLit, IntegerType},
     string::StringLit,
 };
-
 
 // ==============================================================================================
 // ===== `Literal` and type defs
@@ -290,7 +292,6 @@ impl<B: Buffer> fmt::Display for Literal<B> {
         }
     }
 }
-
 
 // ==============================================================================================
 // ===== Buffer

--- a/src/printing/mod.rs
+++ b/src/printing/mod.rs
@@ -1,0 +1,44 @@
+use quote::{ToTokens, TokenStreamExt};
+
+use crate::Buffer;
+
+macro_rules! to_tokens_simple {
+    ($id:ident) => {
+        impl<B: Buffer + Clone> ToTokens for crate::$id<B> {
+            fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+                tokens.append(<Self as Into<proc_macro2::Literal>>::into(self.clone()))
+            }
+
+            fn into_token_stream(self) -> proc_macro2::TokenStream
+            where
+                Self: Sized,
+            {
+                proc_macro2::TokenStream::from(proc_macro2::TokenTree::from(<Self as Into<
+                    proc_macro2::Literal,
+                >>::into(self)))
+            }
+        }
+    };
+}
+to_tokens_simple!(ByteLit);
+to_tokens_simple!(ByteStringLit);
+to_tokens_simple!(CharLit);
+to_tokens_simple!(FloatLit);
+to_tokens_simple!(IntegerLit);
+to_tokens_simple!(StringLit);
+
+impl ToTokens for crate::BoolLit {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        use crate::BoolLit::*;
+        tokens.append(proc_macro2::Ident::new(
+            match self {
+                True => "true",
+                False => "false",
+            },
+            proc_macro2::Span::call_site(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/printing/tests.rs
+++ b/src/printing/tests.rs
@@ -1,0 +1,82 @@
+use proc_macro2::{Literal, TokenTree};
+use quote::ToTokens;
+
+use crate::{ByteLit, ByteStringLit, CharLit, FloatLit, IntegerLit, StringLit};
+
+#[test]
+fn it_preserves_bool_true() {
+    let other = crate::BoolLit::True
+        .to_token_stream()
+        .into_iter()
+        .next()
+        .and_then(|v| {
+            if let TokenTree::Ident(v) = v {
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert_eq!(other, "true")
+}
+#[test]
+fn it_preserves_bool_false() {
+    let other = crate::BoolLit::False
+        .to_token_stream()
+        .into_iter()
+        .next()
+        .and_then(|v| {
+            if let TokenTree::Ident(v) = v {
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    assert_eq!(other, "false")
+}
+
+// NOTE: sometimes the round-trip to quote simplifies literals (for example float literals)
+// this is something that has to be taken into consideration when writing tests
+macro_rules! preservation {
+    ($name:ident : $ty:ident : $($content:tt)+) => {
+        #[test]
+        fn $name() {
+            use std::convert::TryFrom;
+
+            let lit = Literal::$($content)+;
+
+            let lhs = $ty::try_from(lit).unwrap();
+
+            let rhs = $ty::try_from(
+                lhs.to_token_stream()
+                    .into_iter()
+                    .next()
+                    .and_then(|v| {
+                        if let TokenTree::Literal(v) = v {
+                            Some(v)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap(),
+            )
+            .unwrap();
+
+            assert_eq!(lhs, rhs);
+        }
+    }
+}
+
+preservation!(it_preserves_u8_suffixed   : IntegerLit :   u8_suffixed(10));
+preservation!(it_preserves_u8_unsuffixed : IntegerLit : u8_unsuffixed(10));
+
+preservation!(it_preserves_f64_suffixed   : FloatLit :   f64_suffixed(1.1));
+preservation!(it_preserves_f64_unsuffixed : FloatLit : f64_unsuffixed(1.1));
+
+preservation!(it_preserves_strings     : StringLit : string("hello world"));
+preservation!(it_preserves_raw_strings : StringLit : string(r#"hello world"#));
+
+preservation!(it_preserves_char : CharLit : character('1'));
+
+preservation!(it_preserves_bytestring : ByteStringLit : byte_string(b"hello world"));

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,7 +1,6 @@
 use crate::*;
 use std::fmt::{Debug, Display};
 
-
 #[track_caller]
 pub(crate) fn assert_parse_ok_eq<T: PartialEq + Debug + Display>(
     input: &str,
@@ -14,26 +13,20 @@ pub(crate) fn assert_parse_ok_eq<T: PartialEq + Debug + Display>(
             if actual.to_string() != input {
                 panic!(
                     "formatting does not yield original input `{}`: {:?}",
-                    input,
-                    actual,
+                    input, actual,
                 );
             }
         }
         Ok(actual) => {
             panic!(
                 "unexpected parsing result (with `{}`) for `{}`:\nactual:    {:?}\nexpected:  {:?}",
-                parse_method,
-                input,
-                actual,
-                expected,
+                parse_method, input, actual, expected,
             );
         }
         Err(e) => {
             panic!(
                 "expected `{}` to be parsed (with `{}`) successfully, but it failed: {:?}",
-                input,
-                parse_method,
-                e,
+                input, parse_method, e,
             );
         }
     }
@@ -52,7 +45,8 @@ where
     proc_macro2::Literal: From<T>,
     <T as std::convert::TryFrom<proc_macro2::Literal>>::Error: std::fmt::Display,
 {
-    let pm_lit = input.parse::<proc_macro2::Literal>()
+    let pm_lit = input
+        .parse::<proc_macro2::Literal>()
         .expect("failed to parse input as proc_macro2::Literal");
     let t_name = std::any::type_name::<T>();
 
@@ -70,16 +64,17 @@ where
 
     match T::try_from(pm_lit) {
         Err(e) => {
-            panic!("Trying to convert proc_macro2::Literal to {} results in error: {}", t_name, e);
+            panic!(
+                "Trying to convert proc_macro2::Literal to {} results in error: {}",
+                t_name, e
+            );
         }
         Ok(res) => {
             if res != ours {
                 panic!(
                     "Converting proc_macro2::Literal to {} has unexpected result:\
                         \nactual:    {:?}\nexpected:  {:?}",
-                    t_name,
-                    res,
-                    ours,
+                    t_name, res, ours,
                 );
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,5 @@
 use crate::Literal;
 
-
 #[test]
 fn empty() {
     assert_err!(Literal, "", Empty, None);
@@ -91,14 +90,13 @@ fn never_panic_len_4() {
 #[cfg(feature = "proc-macro2")]
 #[test]
 fn proc_macro() {
-    use std::convert::TryFrom;
-    use proc_macro2::{
-        self as pm2, TokenTree, Group, TokenStream, Delimiter, Spacing, Punct, Span, Ident,
-    };
     use crate::{
-        BoolLit, ByteLit, ByteStringLit, CharLit, FloatLit, IntegerLit, StringLit, err::TokenKind
+        err::TokenKind, BoolLit, ByteLit, ByteStringLit, CharLit, FloatLit, IntegerLit, StringLit,
     };
-
+    use proc_macro2::{
+        self as pm2, Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree,
+    };
+    use std::convert::TryFrom;
 
     macro_rules! assert_invalid_token {
         ($input:expr, expected: $expected:path, actual: $actual:path $(,)?) => {
@@ -106,16 +104,17 @@ fn proc_macro() {
             if err.expected != $expected {
                 panic!(
                     "err.expected was expected to be {:?}, but is {:?}",
-                    $expected,
-                    err.expected,
+                    $expected, err.expected,
                 );
             }
             if err.actual != $actual {
-                panic!("err.actual was expected to be {:?}, but is {:?}", $actual, err.actual);
+                panic!(
+                    "err.actual was expected to be {:?}, but is {:?}",
+                    $actual, err.actual
+                );
             }
         };
     }
-
 
     let pm_u16_lit = pm2::Literal::u16_suffixed(2700);
     let pm_i16_lit = pm2::Literal::i16_unsuffixed(3912);
@@ -141,7 +140,6 @@ fn proc_macro() {
     assert_eq!(Literal::from(&pm_bytestr_lit), bytestr_lit);
     assert_eq!(Literal::from(&pm_char_lit), char_lit);
 
-
     let group = TokenTree::from(Group::new(Delimiter::Brace, TokenStream::new()));
     let punct = TokenTree::from(Punct::new(':', Spacing::Alone));
     let ident = TokenTree::from(Ident::new("peter", Span::call_site()));
@@ -166,17 +164,34 @@ fn proc_macro() {
         actual: TokenKind::Ident,
     );
 
-
-    assert_eq!(Literal::from(IntegerLit::try_from(pm_u16_lit.clone()).unwrap()), u16_lit);
-    assert_eq!(Literal::from(IntegerLit::try_from(pm_i16_lit.clone()).unwrap()), i16_lit);
-    assert_eq!(Literal::from(FloatLit::try_from(pm_f32_lit.clone()).unwrap()), f32_lit);
-    assert_eq!(Literal::from(FloatLit::try_from(pm_f64_lit.clone()).unwrap()), f64_lit);
-    assert_eq!(Literal::from(StringLit::try_from(pm_string_lit.clone()).unwrap()), string_lit);
+    assert_eq!(
+        Literal::from(IntegerLit::try_from(pm_u16_lit.clone()).unwrap()),
+        u16_lit
+    );
+    assert_eq!(
+        Literal::from(IntegerLit::try_from(pm_i16_lit.clone()).unwrap()),
+        i16_lit
+    );
+    assert_eq!(
+        Literal::from(FloatLit::try_from(pm_f32_lit.clone()).unwrap()),
+        f32_lit
+    );
+    assert_eq!(
+        Literal::from(FloatLit::try_from(pm_f64_lit.clone()).unwrap()),
+        f64_lit
+    );
+    assert_eq!(
+        Literal::from(StringLit::try_from(pm_string_lit.clone()).unwrap()),
+        string_lit
+    );
     assert_eq!(
         Literal::from(ByteStringLit::try_from(pm_bytestr_lit.clone()).unwrap()),
         bytestr_lit,
     );
-    assert_eq!(Literal::from(CharLit::try_from(pm_char_lit.clone()).unwrap()), char_lit);
+    assert_eq!(
+        Literal::from(CharLit::try_from(pm_char_lit.clone()).unwrap()),
+        char_lit
+    );
 
     assert_invalid_token!(
         StringLit::try_from(pm_u16_lit.clone()),
@@ -208,7 +223,6 @@ fn proc_macro() {
         expected: TokenKind::IntegerLit,
         actual: TokenKind::CharLit,
     );
-
 
     assert_eq!(
         Literal::from(IntegerLit::try_from(TokenTree::from(pm_u16_lit.clone())).unwrap()),
@@ -290,22 +304,26 @@ fn proc_macro() {
 #[cfg(feature = "proc-macro2")]
 #[test]
 fn bool_try_from_tt() {
-    use std::convert::TryFrom;
-    use proc_macro2::{Ident, Span, TokenTree};
     use crate::BoolLit;
-
+    use proc_macro2::{Ident, Span, TokenTree};
+    use std::convert::TryFrom;
 
     let ident = |s: &str| Ident::new(s, Span::call_site());
 
-    assert_eq!(BoolLit::try_from(TokenTree::Ident(ident("true"))).unwrap(), BoolLit::True);
-    assert_eq!(BoolLit::try_from(TokenTree::Ident(ident("false"))).unwrap(), BoolLit::False);
+    assert_eq!(
+        BoolLit::try_from(TokenTree::Ident(ident("true"))).unwrap(),
+        BoolLit::True
+    );
+    assert_eq!(
+        BoolLit::try_from(TokenTree::Ident(ident("false"))).unwrap(),
+        BoolLit::False
+    );
 
     assert!(BoolLit::try_from(TokenTree::Ident(ident("falsex"))).is_err());
     assert!(BoolLit::try_from(TokenTree::Ident(ident("_false"))).is_err());
     assert!(BoolLit::try_from(TokenTree::Ident(ident("False"))).is_err());
     assert!(BoolLit::try_from(TokenTree::Ident(ident("True"))).is_err());
     assert!(BoolLit::try_from(TokenTree::Ident(ident("ltrue"))).is_err());
-
 
     assert_eq!(
         Literal::try_from(TokenTree::Ident(ident("true"))).unwrap(),
@@ -326,7 +344,7 @@ fn bool_try_from_tt() {
 #[cfg(feature = "proc-macro2")]
 #[test]
 fn invalid_token_display() {
-    use crate::{InvalidToken, err::TokenKind};
+    use crate::{err::TokenKind, InvalidToken};
 
     let span = crate::err::Span::Two(proc_macro2::Span::call_site());
     assert_eq!(
@@ -334,7 +352,8 @@ fn invalid_token_display() {
             actual: TokenKind::StringLit,
             expected: TokenKind::FloatLit,
             span,
-        }.to_string(),
+        }
+        .to_string(),
         r#"expected a float literal (e.g. `3.14`), but found a string literal (e.g. "Ferris")"#,
     );
 
@@ -343,7 +362,8 @@ fn invalid_token_display() {
             actual: TokenKind::Punct,
             expected: TokenKind::Literal,
             span,
-        }.to_string(),
+        }
+        .to_string(),
         r#"expected a literal, but found a punctuation character"#,
     );
 }


### PR DESCRIPTION
I have been working with `litrs` in one of my projects for quite some time and started to get annoyed that there was no `quote` integration. To fix this, I have now added a very simple `quote` integration as an optional feature. Does this align with the project's views as light weight? I took this into consideration when implementing it by adding it as its own feature flag.

NOTE: the only contentful commit in this case is [Add quote printing as an optional feature](https://github.com/LukasKalbertodt/litrs/commit/dbbe457b43b84ba4269c8b29c978a690b2e74856). The commit [Run cargo fmt](https://github.com/LukasKalbertodt/litrs/commit/6b67ca0f0271fea644816bfbb217a303a51ccb21) was litterally just running rust fmt and commiting it.

Is there anything im missing for this to be merged into master?