### PR TITLE
feat: `as_ref`

### DIFF
--- a/src/byte/mod.rs
+++ b/src/byte/mod.rs
@@ -56,6 +56,14 @@ impl<B: Buffer> ByteLit<B> {
         self.raw
     }
 
+    /// Returns the reference version of `Self`.
+    pub fn as_ref(&self) -> ByteLit<&str> {
+        ByteLit {
+            raw: self.raw.as_ref(),
+            start_suffix: self.start_suffix,
+            value: self.value,
+        }
+    }
 }
 
 impl ByteLit<&str> {

--- a/src/bytestr/tests.rs
+++ b/src/bytestr/tests.rs
@@ -10,7 +10,7 @@ macro_rules! check {
         let input = $input;
         let expected = ByteStringLit {
             raw: input,
-            value: if $has_escapes { Some($lit.to_vec()) } else { None },
+            value: if $has_escapes { Some(std::borrow::Cow::Borrowed($lit)) } else { None },
             num_hashes: $num_hashes,
             start_suffix: input.len() - $suffix.len(),
         };

--- a/src/char/mod.rs
+++ b/src/char/mod.rs
@@ -53,7 +53,15 @@ impl<B: Buffer> CharLit<B> {
     pub fn into_raw_input(self) -> B {
         self.raw
     }
-
+    
+    /// Returns the reference version of `Self`.
+    pub fn as_ref(&self) -> CharLit<&str> {
+        CharLit {
+            raw: self.raw.as_ref(),
+            start_suffix: self.start_suffix,
+            value: self.value,
+        }
+    }
 }
 
 impl CharLit<&str> {

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -121,6 +121,16 @@ impl<B: Buffer> FloatLit<B> {
     pub fn into_raw_input(self) -> B {
         self.raw
     }
+    
+    /// Returns the reference version of `Self`.
+    pub fn as_ref(&self) -> FloatLit<&str> {
+        FloatLit {
+            raw: self.raw.as_ref(),
+            end_integer_part: self.end_integer_part,
+            end_fractional_part: self.end_fractional_part,
+            end_number_part: self.end_number_part,
+        }
+    }
 }
 
 impl FloatLit<&str> {

--- a/src/integer/mod.rs
+++ b/src/integer/mod.rs
@@ -115,6 +115,16 @@ impl<B: Buffer> IntegerLit<B> {
     pub fn into_raw_input(self) -> B {
         self.raw
     }
+    
+    /// Returns the reference version of `Self`.
+    pub fn as_ref(&self) -> IntegerLit<&str> {
+        IntegerLit {
+            raw: self.raw.as_ref(),
+            start_main_part: self.start_main_part,
+            end_main_part: self.end_main_part,
+            base: self.base,
+        }
+    }
 }
 
 impl IntegerLit<&str> {

--- a/src/string/tests.rs
+++ b/src/string/tests.rs
@@ -10,7 +10,7 @@ macro_rules! check {
         let input = $input;
         let expected = StringLit {
             raw: input,
-            value: if $has_escapes { Some($lit.to_string()) } else { None },
+            value: if $has_escapes { Some(::std::borrow::Cow::Borrowed($lit)) } else { None },
             num_hashes: $num_hashes,
             start_suffix: input.len() - $suffix.len(),
         };


### PR DESCRIPTION
This does introduce `Buffer::CStrCow` to help avoid cloning for `CString`s.